### PR TITLE
Include LICENSE.txt file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_file = LICENSE.txt


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.